### PR TITLE
Fix newline in help.

### DIFF
--- a/form/form.go
+++ b/form/form.go
@@ -512,7 +512,7 @@ func BuildField(fileDescriptorSet *descriptor.FileDescriptorSet, msg *descriptor
 		if !f.IsRepeated() {
 			return `s += '<div class="children" type="` + typName + `">' + build` + typName + `(json["` + f.GetName() + `"]);
 			s += '</div>';
-		s += setLink(json, "` + typName + `", "` + fieldname + `", "` + help + `");
+		s += setLink(json, "` + typName + `", "` + fieldname + `", "` + strings.Replace(help, "\n", "\\n", -1) + `");
 		`
 		} else {
 			return `s += '<div class="children" type="` + typName + `">';


### PR DESCRIPTION
Before this commit, it was possible for the following output to be
generated:

    s += setLink(json, "Message_field", "field", " Abcd efg hij
    klm nop");

This broke the form when viewed in the browser.