### PR TITLE
html: add functions for Handler and DefaultHandler

### DIFF
--- a/letmetestserver/serve/serve.pb.go
+++ b/letmetestserver/serve/serve.pb.go
@@ -31,6 +31,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.GoGoProtoPackageIsVersion1
+
 type Instrument int32
 
 const (
@@ -53,6 +57,7 @@ var Instrument_value = map[string]int32{
 func (x Instrument) String() string {
 	return proto.EnumName(Instrument_name, int32(x))
 }
+func (Instrument) EnumDescriptor() ([]byte, []int) { return fileDescriptorServe, []int{0} }
 
 type Genre int32
 
@@ -88,28 +93,31 @@ var Genre_value = map[string]int32{
 func (x Genre) String() string {
 	return proto.EnumName(Genre_name, int32(x))
 }
+func (Genre) EnumDescriptor() ([]byte, []int) { return fileDescriptorServe, []int{1} }
 
 type Artist struct {
 	// Pick something original
-	Name string     `protobuf:"bytes,1,opt,name=Name,proto3" json:"Name,omitempty"`
-	Role Instrument `protobuf:"varint,2,opt,name=Role,proto3,enum=serve.Instrument" json:"Role,omitempty"`
+	Name string     `protobuf:"bytes,1,opt,name=Name,json=name,proto3" json:"Name,omitempty"`
+	Role Instrument `protobuf:"varint,2,opt,name=Role,json=role,proto3,enum=serve.Instrument" json:"Role,omitempty"`
 }
 
-func (m *Artist) Reset()         { *m = Artist{} }
-func (m *Artist) String() string { return proto.CompactTextString(m) }
-func (*Artist) ProtoMessage()    {}
+func (m *Artist) Reset()                    { *m = Artist{} }
+func (m *Artist) String() string            { return proto.CompactTextString(m) }
+func (*Artist) ProtoMessage()               {}
+func (*Artist) Descriptor() ([]byte, []int) { return fileDescriptorServe, []int{0} }
 
 type Song struct {
-	Name string `protobuf:"bytes,1,opt,name=Name,proto3" json:"Name,omitempty"`
+	Name string `protobuf:"bytes,1,opt,name=Name,json=name,proto3" json:"Name,omitempty"`
 	// 1,2,3,4...
-	Track    uint64    `protobuf:"varint,2,opt,name=Track,proto3" json:"Track,omitempty"`
-	Duration float64   `protobuf:"fixed64,3,opt,name=Duration,proto3" json:"Duration,omitempty"`
-	Composer []*Artist `protobuf:"bytes,4,rep,name=Composer" json:"Composer,omitempty"`
+	Track    uint64    `protobuf:"varint,2,opt,name=Track,json=track,proto3" json:"Track,omitempty"`
+	Duration float64   `protobuf:"fixed64,3,opt,name=Duration,json=duration,proto3" json:"Duration,omitempty"`
+	Composer []*Artist `protobuf:"bytes,4,rep,name=Composer,json=composer" json:"Composer,omitempty"`
 }
 
-func (m *Song) Reset()         { *m = Song{} }
-func (m *Song) String() string { return proto.CompactTextString(m) }
-func (*Song) ProtoMessage()    {}
+func (m *Song) Reset()                    { *m = Song{} }
+func (m *Song) String() string            { return proto.CompactTextString(m) }
+func (*Song) ProtoMessage()               {}
+func (*Song) Descriptor() ([]byte, []int) { return fileDescriptorServe, []int{1} }
 
 func (m *Song) GetComposer() []*Artist {
 	if m != nil {
@@ -120,22 +128,23 @@ func (m *Song) GetComposer() []*Artist {
 
 type Album struct {
 	// Untitled?
-	Name  string  `protobuf:"bytes,1,opt,name=Name,proto3" json:"Name,omitempty"`
-	Song  []*Song `protobuf:"bytes,2,rep,name=Song" json:"Song,omitempty"`
-	Genre Genre   `protobuf:"varint,3,opt,name=Genre,proto3,enum=serve.Genre" json:"Genre,omitempty"`
+	Name  string  `protobuf:"bytes,1,opt,name=Name,json=name,proto3" json:"Name,omitempty"`
+	Song  []*Song `protobuf:"bytes,2,rep,name=Song,json=song" json:"Song,omitempty"`
+	Genre Genre   `protobuf:"varint,3,opt,name=Genre,json=genre,proto3,enum=serve.Genre" json:"Genre,omitempty"`
 	// 2015
-	Year string `protobuf:"bytes,4,opt,name=Year,proto3" json:"Year,omitempty"`
+	Year string `protobuf:"bytes,4,opt,name=Year,json=year,proto3" json:"Year,omitempty"`
 	// Uhm ja
-	Producer []string `protobuf:"bytes,5,rep,name=Producer" json:"Producer,omitempty"`
-	Mediocre bool     `protobuf:"varint,6,opt,name=Mediocre,proto3" json:"Mediocre,omitempty"`
-	Rated    bool     `protobuf:"varint,7,opt,name=Rated,proto3" json:"Rated,omitempty"`
-	Epilogue string   `protobuf:"bytes,8,opt,name=Epilogue,proto3" json:"Epilogue,omitempty"`
-	Likes    []bool   `protobuf:"varint,9,rep,name=Likes" json:"Likes,omitempty"`
+	Producer []string `protobuf:"bytes,5,rep,name=Producer,json=producer" json:"Producer,omitempty"`
+	Mediocre bool     `protobuf:"varint,6,opt,name=Mediocre,json=mediocre,proto3" json:"Mediocre,omitempty"`
+	Rated    bool     `protobuf:"varint,7,opt,name=Rated,json=rated,proto3" json:"Rated,omitempty"`
+	Epilogue string   `protobuf:"bytes,8,opt,name=Epilogue,json=epilogue,proto3" json:"Epilogue,omitempty"`
+	Likes    []bool   `protobuf:"varint,9,rep,name=Likes,json=likes" json:"Likes,omitempty"`
 }
 
-func (m *Album) Reset()         { *m = Album{} }
-func (m *Album) String() string { return proto.CompactTextString(m) }
-func (*Album) ProtoMessage()    {}
+func (m *Album) Reset()                    { *m = Album{} }
+func (m *Album) String() string            { return proto.CompactTextString(m) }
+func (*Album) ProtoMessage()               {}
+func (*Album) Descriptor() ([]byte, []int) { return fileDescriptorServe, []int{2} }
 
 func (m *Album) GetSong() []*Song {
 	if m != nil {
@@ -145,12 +154,13 @@ func (m *Album) GetSong() []*Song {
 }
 
 type EndLess struct {
-	Tree *Tree `protobuf:"bytes,1,opt,name=Tree" json:"Tree,omitempty"`
+	Tree *Tree `protobuf:"bytes,1,opt,name=Tree,json=tree" json:"Tree,omitempty"`
 }
 
-func (m *EndLess) Reset()         { *m = EndLess{} }
-func (m *EndLess) String() string { return proto.CompactTextString(m) }
-func (*EndLess) ProtoMessage()    {}
+func (m *EndLess) Reset()                    { *m = EndLess{} }
+func (m *EndLess) String() string            { return proto.CompactTextString(m) }
+func (*EndLess) ProtoMessage()               {}
+func (*EndLess) Descriptor() ([]byte, []int) { return fileDescriptorServe, []int{3} }
 
 func (m *EndLess) GetTree() *Tree {
 	if m != nil {
@@ -160,14 +170,15 @@ func (m *EndLess) GetTree() *Tree {
 }
 
 type Tree struct {
-	Value string `protobuf:"bytes,1,opt,name=Value,proto3" json:"Value,omitempty"`
-	Left  *Tree  `protobuf:"bytes,2,opt,name=Left" json:"Left,omitempty"`
-	Right *Tree  `protobuf:"bytes,3,opt,name=Right" json:"Right,omitempty"`
+	Value string `protobuf:"bytes,1,opt,name=Value,json=value,proto3" json:"Value,omitempty"`
+	Left  *Tree  `protobuf:"bytes,2,opt,name=Left,json=left" json:"Left,omitempty"`
+	Right *Tree  `protobuf:"bytes,3,opt,name=Right,json=right" json:"Right,omitempty"`
 }
 
-func (m *Tree) Reset()         { *m = Tree{} }
-func (m *Tree) String() string { return proto.CompactTextString(m) }
-func (*Tree) ProtoMessage()    {}
+func (m *Tree) Reset()                    { *m = Tree{} }
+func (m *Tree) String() string            { return proto.CompactTextString(m) }
+func (*Tree) ProtoMessage()               {}
+func (*Tree) Descriptor() ([]byte, []int) { return fileDescriptorServe, []int{4} }
 
 func (m *Tree) GetLeft() *Tree {
 	if m != nil {
@@ -196,6 +207,10 @@ func init() {
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn
+
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the grpc package it is being compiled against.
+const _ = grpc.SupportPackageIsVersion2
 
 // Client API for Label service
 
@@ -241,28 +256,40 @@ func RegisterLabelServer(s *grpc.Server, srv LabelServer) {
 	s.RegisterService(&_Label_serviceDesc, srv)
 }
 
-func _Label_Produce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _Label_Produce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(Album)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(LabelServer).Produce(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(LabelServer).Produce(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/serve.Label/Produce",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LabelServer).Produce(ctx, req.(*Album))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
-func _Label_Loop_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _Label_Loop_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(EndLess)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(LabelServer).Loop(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(LabelServer).Loop(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/serve.Label/Loop",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LabelServer).Loop(ctx, req.(*EndLess))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 var _Label_serviceDesc = grpc.ServiceDesc{
@@ -279,4 +306,40 @@ var _Label_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams: []grpc.StreamDesc{},
+}
+
+var fileDescriptorServe = []byte{
+	// 497 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x6c, 0x53, 0x5d, 0x6b, 0xdb, 0x30,
+	0x14, 0x5d, 0x12, 0x2b, 0x51, 0x94, 0x2e, 0x78, 0x62, 0x0f, 0x26, 0x2f, 0xeb, 0x0c, 0x1b, 0x5d,
+	0x60, 0x7d, 0xc8, 0x7e, 0x41, 0x49, 0x4a, 0xe9, 0xc8, 0x4a, 0xd0, 0x4a, 0x61, 0x6f, 0x73, 0xec,
+	0xbb, 0xcc, 0xc4, 0x91, 0x8c, 0x2c, 0x77, 0xac, 0xbf, 0x7b, 0x3f, 0x60, 0xf7, 0xca, 0x2a, 0xa5,
+	0xa1, 0x2f, 0x89, 0xce, 0xfd, 0x38, 0xe7, 0xe8, 0xea, 0x5a, 0x4c, 0x1a, 0xb0, 0xf7, 0x70, 0x5e,
+	0x5b, 0xe3, 0x8c, 0x64, 0x1e, 0xa4, 0x4b, 0x31, 0xbc, 0xb0, 0xae, 0x6c, 0x9c, 0x94, 0x22, 0xba,
+	0xc9, 0x0e, 0x90, 0xf4, 0x4e, 0x7b, 0x67, 0x63, 0x15, 0x69, 0x3c, 0xcb, 0x0f, 0x22, 0x52, 0xa6,
+	0x82, 0xa4, 0x8f, 0xb1, 0xe9, 0xe2, 0xcd, 0x79, 0x47, 0x70, 0xad, 0x1b, 0x67, 0xdb, 0x03, 0x68,
+	0xa7, 0x22, 0x8b, 0xe9, 0xf4, 0x8f, 0x88, 0xbe, 0x1b, 0xbd, 0x7b, 0x91, 0xe2, 0xad, 0x60, 0xb7,
+	0x36, 0xcb, 0xf7, 0x9e, 0x23, 0x52, 0xcc, 0x11, 0x90, 0x33, 0xc1, 0x57, 0xad, 0xcd, 0x5c, 0x69,
+	0x74, 0x32, 0xc0, 0x44, 0x4f, 0xf1, 0x22, 0x60, 0xf9, 0x49, 0xf0, 0xa5, 0x39, 0xd4, 0x06, 0xc5,
+	0x92, 0xe8, 0x74, 0x70, 0x36, 0x59, 0xbc, 0x0e, 0xc2, 0x9d, 0x53, 0xc5, 0xf3, 0x90, 0x4e, 0xff,
+	0xf5, 0x04, 0xbb, 0xa8, 0xb6, 0xed, 0xe1, 0x45, 0xe9, 0x77, 0x9d, 0x2d, 0x54, 0x26, 0x92, 0x49,
+	0x20, 0xa1, 0x90, 0x8a, 0x1a, 0xf2, 0x9b, 0x0a, 0x76, 0x05, 0xda, 0x82, 0xb7, 0x30, 0x5d, 0x9c,
+	0x84, 0x0a, 0x1f, 0x53, 0x6c, 0x47, 0x7f, 0x44, 0xfc, 0x03, 0x32, 0x72, 0xe2, 0x89, 0xff, 0xe2,
+	0x99, 0xdc, 0x6f, 0xac, 0x29, 0xda, 0x1c, 0x1d, 0x32, 0x24, 0x1f, 0x2b, 0x5e, 0x07, 0x4c, 0xb9,
+	0x6f, 0x50, 0x94, 0x26, 0x47, 0xda, 0x21, 0xf6, 0x70, 0xc5, 0x0f, 0x01, 0xd3, 0x2c, 0x54, 0xe6,
+	0xa0, 0x48, 0x46, 0x3e, 0xc1, 0x2c, 0x01, 0xea, 0xb8, 0xac, 0xcb, 0xca, 0xec, 0x5a, 0x48, 0xb8,
+	0x57, 0xe1, 0x10, 0x30, 0x75, 0xac, 0xcb, 0x3d, 0x34, 0xc9, 0x18, 0x65, 0xb0, 0xa3, 0x22, 0x90,
+	0xce, 0xc5, 0xe8, 0x52, 0x17, 0x6b, 0x68, 0x1a, 0xba, 0xe3, 0xad, 0x85, 0xee, 0xde, 0x4f, 0x77,
+	0xa4, 0x90, 0x8a, 0x1c, 0xfe, 0xa6, 0x3f, 0xbb, 0x02, 0x62, 0xba, 0xcb, 0xaa, 0xf6, 0x71, 0x42,
+	0xec, 0x9e, 0x00, 0xb5, 0xaf, 0xe1, 0x97, 0xf3, 0x8f, 0x73, 0xdc, 0x5e, 0x61, 0x42, 0xbe, 0x47,
+	0xcb, 0xe5, 0xee, 0xb7, 0xf3, 0x23, 0x3a, 0xaa, 0x60, 0x96, 0x32, 0xf3, 0xcf, 0x42, 0x3c, 0x6d,
+	0x84, 0x1c, 0xa3, 0x8e, 0x29, 0x73, 0x88, 0x5f, 0x49, 0x21, 0x86, 0x57, 0x6d, 0xe9, 0x32, 0x1b,
+	0xf7, 0x24, 0x17, 0xd1, 0x0a, 0x2b, 0xe2, 0xfe, 0xfc, 0x2e, 0x0c, 0x5d, 0x8e, 0xc4, 0x60, 0x63,
+	0x6a, 0xac, 0xe3, 0xb4, 0x65, 0xf9, 0xbe, 0xab, 0xfa, 0x9a, 0x3d, 0x3c, 0xc4, 0x7d, 0x19, 0x8b,
+	0x93, 0x9b, 0x52, 0x3b, 0xd0, 0x85, 0x59, 0x1a, 0x0b, 0xf1, 0x80, 0x88, 0xaf, 0x75, 0x51, 0x42,
+	0x1c, 0x51, 0xd9, 0xa6, 0xd5, 0xfb, 0x98, 0x51, 0x70, 0x95, 0x69, 0x54, 0x1b, 0x2e, 0x90, 0x77,
+	0x9d, 0x6d, 0xa1, 0xc2, 0xa5, 0x1d, 0x85, 0xd7, 0x91, 0x8f, 0x2f, 0xea, 0x77, 0x64, 0xf6, 0x0c,
+	0xc9, 0x8f, 0x78, 0x75, 0x63, 0x6a, 0x39, 0x0d, 0xd1, 0x30, 0xd1, 0xd9, 0x11, 0xde, 0x0e, 0xfd,
+	0xf7, 0xf2, 0xe5, 0x7f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x70, 0xe9, 0x55, 0x35, 0x3e, 0x03, 0x00,
+	0x00,
 }

--- a/test/grpc.letmegrpc.go
+++ b/test/grpc.letmegrpc.go
@@ -3,16 +3,16 @@
 // DO NOT EDIT!
 
 /*
-Package grpc is a generated protocol buffer package.
+	Package grpc is a generated protocol buffer package.
 
-It is generated from these files:
-	grpc.proto
+	It is generated from these files:
+		grpc.proto
 
-It has these top-level messages:
-	MyRequest
-	MyResponse
-	MyMsg
-	MyMsg2
+	It has these top-level messages:
+		MyRequest
+		MyResponse
+		MyMsg
+		MyMsg2
 */
 package grpc
 
@@ -55,6 +55,26 @@ func Serve(httpAddr, grpcAddr string, stringer func(req, resp interface{}) ([]by
 	if err := net_http.ListenAndServe(httpAddr, nil); err != nil {
 		log.Fatal(err)
 	}
+}
+func Handler(conn *google_golang_org_grpc.ClientConn, stringer func(req, resp interface{}) ([]byte, error)) net_http.Handler {
+	muxhandler := net_http.NewServeMux()
+	MyTestClient := NewMyTestClient(conn)
+	MyTestServer := NewHTMLMyTestServer(MyTestClient, stringer)
+	muxhandler.HandleFunc("/MyTest/UnaryCall", MyTestServer.UnaryCall)
+	muxhandler.HandleFunc("/MyTest/Downstream", MyTestServer.Downstream)
+	muxhandler.HandleFunc("/MyTest/Upstream", MyTestServer.Upstream)
+	muxhandler.HandleFunc("/MyTest/Bidi", MyTestServer.Bidi)
+	return muxhandler
+}
+func DefaultHandler(conn *google_golang_org_grpc.ClientConn) net_http.Handler {
+	muxhandler := net_http.NewServeMux()
+	MyTestClient := NewMyTestClient(conn)
+	MyTestServer := NewHTMLMyTestServer(MyTestClient, DefaultHtmlStringer)
+	muxhandler.HandleFunc("/MyTest/UnaryCall", MyTestServer.UnaryCall)
+	muxhandler.HandleFunc("/MyTest/Downstream", MyTestServer.Downstream)
+	muxhandler.HandleFunc("/MyTest/Upstream", MyTestServer.Upstream)
+	muxhandler.HandleFunc("/MyTest/Bidi", MyTestServer.Bidi)
+	return muxhandler
 }
 
 type htmlMyTest struct {

--- a/test/grpc.pb.go
+++ b/test/grpc.pb.go
@@ -30,38 +30,46 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.GoGoProtoPackageIsVersion1
+
 type MyRequest struct {
-	Value  int64 `protobuf:"varint,1,opt,name=Value,proto3" json:"Value,omitempty"`
-	Value2 int32 `protobuf:"varint,2,opt,name=Value2,proto3" json:"Value2,omitempty"`
+	Value  int64 `protobuf:"varint,1,opt,name=Value,json=value,proto3" json:"Value,omitempty"`
+	Value2 int32 `protobuf:"varint,2,opt,name=Value2,json=value2,proto3" json:"Value2,omitempty"`
 }
 
-func (m *MyRequest) Reset()         { *m = MyRequest{} }
-func (m *MyRequest) String() string { return proto.CompactTextString(m) }
-func (*MyRequest) ProtoMessage()    {}
+func (m *MyRequest) Reset()                    { *m = MyRequest{} }
+func (m *MyRequest) String() string            { return proto.CompactTextString(m) }
+func (*MyRequest) ProtoMessage()               {}
+func (*MyRequest) Descriptor() ([]byte, []int) { return fileDescriptorGrpc, []int{0} }
 
 type MyResponse struct {
-	Value int64 `protobuf:"varint,1,opt,name=Value,proto3" json:"Value,omitempty"`
+	Value int64 `protobuf:"varint,1,opt,name=Value,json=value,proto3" json:"Value,omitempty"`
 }
 
-func (m *MyResponse) Reset()         { *m = MyResponse{} }
-func (m *MyResponse) String() string { return proto.CompactTextString(m) }
-func (*MyResponse) ProtoMessage()    {}
+func (m *MyResponse) Reset()                    { *m = MyResponse{} }
+func (m *MyResponse) String() string            { return proto.CompactTextString(m) }
+func (*MyResponse) ProtoMessage()               {}
+func (*MyResponse) Descriptor() ([]byte, []int) { return fileDescriptorGrpc, []int{1} }
 
 type MyMsg struct {
-	Value int64 `protobuf:"varint,1,opt,name=Value,proto3" json:"Value,omitempty"`
+	Value int64 `protobuf:"varint,1,opt,name=Value,json=value,proto3" json:"Value,omitempty"`
 }
 
-func (m *MyMsg) Reset()         { *m = MyMsg{} }
-func (m *MyMsg) String() string { return proto.CompactTextString(m) }
-func (*MyMsg) ProtoMessage()    {}
+func (m *MyMsg) Reset()                    { *m = MyMsg{} }
+func (m *MyMsg) String() string            { return proto.CompactTextString(m) }
+func (*MyMsg) ProtoMessage()               {}
+func (*MyMsg) Descriptor() ([]byte, []int) { return fileDescriptorGrpc, []int{2} }
 
 type MyMsg2 struct {
-	Value int64 `protobuf:"varint,1,opt,name=Value,proto3" json:"Value,omitempty"`
+	Value int64 `protobuf:"varint,1,opt,name=Value,json=value,proto3" json:"Value,omitempty"`
 }
 
-func (m *MyMsg2) Reset()         { *m = MyMsg2{} }
-func (m *MyMsg2) String() string { return proto.CompactTextString(m) }
-func (*MyMsg2) ProtoMessage()    {}
+func (m *MyMsg2) Reset()                    { *m = MyMsg2{} }
+func (m *MyMsg2) String() string            { return proto.CompactTextString(m) }
+func (*MyMsg2) ProtoMessage()               {}
+func (*MyMsg2) Descriptor() ([]byte, []int) { return fileDescriptorGrpc, []int{3} }
 
 func init() {
 	proto.RegisterType((*MyRequest)(nil), "grpc.MyRequest")
@@ -73,6 +81,10 @@ func init() {
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc1.ClientConn
+
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the grpc package it is being compiled against.
+const _ = grpc1.SupportPackageIsVersion2
 
 // Client API for MyTest service
 
@@ -216,16 +228,22 @@ func RegisterMyTestServer(s *grpc1.Server, srv MyTestServer) {
 	s.RegisterService(&_MyTest_serviceDesc, srv)
 }
 
-func _MyTest_UnaryCall_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _MyTest_UnaryCall_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc1.UnaryServerInterceptor) (interface{}, error) {
 	in := new(MyRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(MyTestServer).UnaryCall(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(MyTestServer).UnaryCall(ctx, in)
 	}
-	return out, nil
+	info := &grpc1.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/grpc.MyTest/UnaryCall",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTestServer).UnaryCall(ctx, req.(*MyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _MyTest_Downstream_Handler(srv interface{}, stream grpc1.ServerStream) error {
@@ -328,4 +346,22 @@ var _MyTest_serviceDesc = grpc1.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
+}
+
+var fileDescriptorGrpc = []byte{
+	// 216 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xe2, 0x4a, 0x2f, 0x2a, 0x48,
+	0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x01, 0xb1, 0x95, 0x2c, 0xb9, 0x38, 0x7d, 0x2b,
+	0x83, 0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b, 0x84, 0x44, 0xb8, 0x58, 0xc3, 0x12, 0x73, 0x4a, 0x53,
+	0x25, 0x18, 0x15, 0x18, 0x35, 0x98, 0x83, 0x58, 0xcb, 0x40, 0x1c, 0x21, 0x31, 0x2e, 0x36, 0xb0,
+	0xa8, 0x91, 0x04, 0x13, 0x50, 0x98, 0x35, 0x88, 0x0d, 0x2c, 0x6c, 0xa4, 0xa4, 0xc4, 0xc5, 0x05,
+	0xd2, 0x5a, 0x5c, 0x90, 0x9f, 0x57, 0x9c, 0x8a, 0x5d, 0xaf, 0x92, 0x2c, 0x17, 0xab, 0x6f, 0xa5,
+	0x6f, 0x71, 0x3a, 0x0e, 0x69, 0x39, 0x2e, 0x36, 0xb0, 0xb4, 0x11, 0x76, 0x79, 0xa3, 0x5d, 0x8c,
+	0x20, 0x05, 0x21, 0x20, 0xb7, 0xe9, 0x71, 0x71, 0x86, 0xe6, 0x25, 0x16, 0x55, 0x3a, 0x27, 0xe6,
+	0xe4, 0x08, 0xf1, 0xeb, 0x81, 0x3d, 0x02, 0x77, 0xb9, 0x94, 0x00, 0x42, 0x00, 0xea, 0x1e, 0x1d,
+	0x2e, 0x2e, 0x97, 0xfc, 0xf2, 0xbc, 0xe2, 0x92, 0xa2, 0xd4, 0xc4, 0x5c, 0x4c, 0x0d, 0xdc, 0x30,
+	0x01, 0xa0, 0xed, 0x06, 0x8c, 0x42, 0xda, 0x5c, 0x1c, 0xa1, 0x05, 0x50, 0xb5, 0xc8, 0x52, 0x98,
+	0x06, 0x6b, 0x30, 0x0a, 0xa9, 0x72, 0xb1, 0x38, 0x65, 0xa6, 0x64, 0xa2, 0x2a, 0xe4, 0x41, 0xe2,
+	0x18, 0x69, 0x30, 0x1a, 0x30, 0x26, 0xb1, 0x81, 0xc3, 0xd9, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff,
+	0xf6, 0x1f, 0xe1, 0xe1, 0x75, 0x01, 0x00, 0x00,
 }

--- a/testimport/import.letmegrpc.go
+++ b/testimport/import.letmegrpc.go
@@ -3,12 +3,12 @@
 // DO NOT EDIT!
 
 /*
-Package testimport is a generated protocol buffer package.
+	Package testimport is a generated protocol buffer package.
 
-It is generated from these files:
-	import.proto
+	It is generated from these files:
+		import.proto
 
-It has these top-level messages:
+	It has these top-level messages:
 */
 package testimport
 
@@ -49,6 +49,20 @@ func Serve(httpAddr, grpcAddr string, stringer func(req, resp interface{}) ([]by
 	if err := net_http.ListenAndServe(httpAddr, nil); err != nil {
 		log.Fatal(err)
 	}
+}
+func Handler(conn *google_golang_org_grpc.ClientConn, stringer func(req, resp interface{}) ([]byte, error)) net_http.Handler {
+	muxhandler := net_http.NewServeMux()
+	OtherLabelClient := NewOtherLabelClient(conn)
+	OtherLabelServer := NewHTMLOtherLabelServer(OtherLabelClient, stringer)
+	muxhandler.HandleFunc("/OtherLabel/Produce", OtherLabelServer.Produce)
+	return muxhandler
+}
+func DefaultHandler(conn *google_golang_org_grpc.ClientConn) net_http.Handler {
+	muxhandler := net_http.NewServeMux()
+	OtherLabelClient := NewOtherLabelClient(conn)
+	OtherLabelServer := NewHTMLOtherLabelServer(OtherLabelClient, DefaultHtmlStringer)
+	muxhandler.HandleFunc("/OtherLabel/Produce", OtherLabelServer.Produce)
+	return muxhandler
 }
 
 type htmlOtherLabel struct {

--- a/testimport/import.pb.go
+++ b/testimport/import.pb.go
@@ -27,9 +27,17 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.GoGoProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn
+
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the grpc package it is being compiled against.
+const _ = grpc.SupportPackageIsVersion2
 
 // Client API for OtherLabel service
 
@@ -64,16 +72,22 @@ func RegisterOtherLabelServer(s *grpc.Server, srv OtherLabelServer) {
 	s.RegisterService(&_OtherLabel_serviceDesc, srv)
 }
 
-func _OtherLabel_Produce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _OtherLabel_Produce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(serve.Album)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(OtherLabelServer).Produce(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(OtherLabelServer).Produce(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/testimport.OtherLabel/Produce",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OtherLabelServer).Produce(ctx, req.(*serve.Album))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 var _OtherLabel_serviceDesc = grpc.ServiceDesc{
@@ -86,4 +100,17 @@ var _OtherLabel_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams: []grpc.StreamDesc{},
+}
+
+var fileDescriptorImport = []byte{
+	// 132 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xe2, 0xc9, 0xcc, 0x2d, 0xc8,
+	0x2f, 0x2a, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x2a, 0x49, 0x2d, 0x2e, 0x81, 0x88,
+	0x48, 0x59, 0xa7, 0x67, 0x96, 0x64, 0x94, 0x26, 0xe9, 0x25, 0xe7, 0xe7, 0xea, 0xa7, 0xe7, 0xa7,
+	0xe7, 0xeb, 0xe7, 0xa4, 0x96, 0xe4, 0xa6, 0xa6, 0x17, 0x15, 0x24, 0x43, 0x58, 0x20, 0xa5, 0xc5,
+	0xa9, 0x45, 0x65, 0xa9, 0x45, 0xfa, 0x60, 0x0a, 0x42, 0x42, 0x0c, 0x32, 0x32, 0xe6, 0xe2, 0xf2,
+	0x2f, 0xc9, 0x48, 0x2d, 0xf2, 0x49, 0x4c, 0x4a, 0xcd, 0x11, 0x52, 0xe5, 0x62, 0x0f, 0x28, 0xca,
+	0x4f, 0x29, 0x4d, 0x4e, 0x15, 0xe2, 0xd1, 0x83, 0x28, 0x73, 0xcc, 0x49, 0x2a, 0xcd, 0x95, 0x42,
+	0xe1, 0x25, 0xb1, 0x81, 0xf5, 0x1a, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0x4d, 0x0c, 0xfe, 0x49,
+	0x94, 0x00, 0x00, 0x00,
 }

--- a/testproto2/proto2.letmegrpc.go
+++ b/testproto2/proto2.letmegrpc.go
@@ -3,15 +3,15 @@
 // DO NOT EDIT!
 
 /*
-Package proto2 is a generated protocol buffer package.
+	Package proto2 is a generated protocol buffer package.
 
-It is generated from these files:
-	proto2.proto
+	It is generated from these files:
+		proto2.proto
 
-It has these top-level messages:
-	Artist
-	Song
-	Album
+	It has these top-level messages:
+		Artist
+		Song
+		Album
 */
 package proto2
 
@@ -51,6 +51,20 @@ func Serve(httpAddr, grpcAddr string, stringer func(req, resp interface{}) ([]by
 	if err := net_http.ListenAndServe(httpAddr, nil); err != nil {
 		log.Fatal(err)
 	}
+}
+func Handler(conn *google_golang_org_grpc.ClientConn, stringer func(req, resp interface{}) ([]byte, error)) net_http.Handler {
+	muxhandler := net_http.NewServeMux()
+	Proto2Client := NewProto2Client(conn)
+	Proto2Server := NewHTMLProto2Server(Proto2Client, stringer)
+	muxhandler.HandleFunc("/Proto2/Produce", Proto2Server.Produce)
+	return muxhandler
+}
+func DefaultHandler(conn *google_golang_org_grpc.ClientConn) net_http.Handler {
+	muxhandler := net_http.NewServeMux()
+	Proto2Client := NewProto2Client(conn)
+	Proto2Server := NewHTMLProto2Server(Proto2Client, DefaultHtmlStringer)
+	muxhandler.HandleFunc("/Proto2/Produce", Proto2Server.Produce)
+	return muxhandler
 }
 
 type htmlProto2 struct {

--- a/testproto2/proto2.pb.go
+++ b/testproto2/proto2.pb.go
@@ -29,6 +29,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.GoGoProtoPackageIsVersion1
+
 type Instrument int32
 
 const (
@@ -64,6 +68,7 @@ func (x *Instrument) UnmarshalJSON(data []byte) error {
 	*x = Instrument(value)
 	return nil
 }
+func (Instrument) EnumDescriptor() ([]byte, []int) { return fileDescriptorProto2, []int{0} }
 
 type Genre int32
 
@@ -112,16 +117,18 @@ func (x *Genre) UnmarshalJSON(data []byte) error {
 	*x = Genre(value)
 	return nil
 }
+func (Genre) EnumDescriptor() ([]byte, []int) { return fileDescriptorProto2, []int{1} }
 
 type Artist struct {
-	Name             *string     `protobuf:"bytes,1,opt,name=Name" json:"Name,omitempty"`
-	Role             *Instrument `protobuf:"varint,2,opt,name=Role,enum=proto2.Instrument,def=1" json:"Role,omitempty"`
+	Name             *string     `protobuf:"bytes,1,opt,name=Name,json=name" json:"Name,omitempty"`
+	Role             *Instrument `protobuf:"varint,2,opt,name=Role,json=role,enum=proto2.Instrument,def=1" json:"Role,omitempty"`
 	XXX_unrecognized []byte      `json:"-"`
 }
 
-func (m *Artist) Reset()         { *m = Artist{} }
-func (m *Artist) String() string { return proto.CompactTextString(m) }
-func (*Artist) ProtoMessage()    {}
+func (m *Artist) Reset()                    { *m = Artist{} }
+func (m *Artist) String() string            { return proto.CompactTextString(m) }
+func (*Artist) ProtoMessage()               {}
+func (*Artist) Descriptor() ([]byte, []int) { return fileDescriptorProto2, []int{0} }
 
 const Default_Artist_Role Instrument = Instrument_Guitar
 
@@ -140,17 +147,18 @@ func (m *Artist) GetRole() Instrument {
 }
 
 type Song struct {
-	Name             *string   `protobuf:"bytes,1,opt,name=Name,def=Type in a Name" json:"Name,omitempty"`
-	Track            *uint64   `protobuf:"varint,2,opt,name=Track,def=1" json:"Track,omitempty"`
-	Duration         *float64  `protobuf:"fixed64,3,opt,name=Duration,def=3.3" json:"Duration,omitempty"`
-	Composer         []*Artist `protobuf:"bytes,4,rep,name=Composer" json:"Composer,omitempty"`
-	Good             *bool     `protobuf:"varint,5,opt,name=Good,def=1" json:"Good,omitempty"`
+	Name             *string   `protobuf:"bytes,1,opt,name=Name,json=name,def=Type in a Name" json:"Name,omitempty"`
+	Track            *uint64   `protobuf:"varint,2,opt,name=Track,json=track,def=1" json:"Track,omitempty"`
+	Duration         *float64  `protobuf:"fixed64,3,opt,name=Duration,json=duration,def=3.3" json:"Duration,omitempty"`
+	Composer         []*Artist `protobuf:"bytes,4,rep,name=Composer,json=composer" json:"Composer,omitempty"`
+	Good             *bool     `protobuf:"varint,5,opt,name=Good,json=good,def=1" json:"Good,omitempty"`
 	XXX_unrecognized []byte    `json:"-"`
 }
 
-func (m *Song) Reset()         { *m = Song{} }
-func (m *Song) String() string { return proto.CompactTextString(m) }
-func (*Song) ProtoMessage()    {}
+func (m *Song) Reset()                    { *m = Song{} }
+func (m *Song) String() string            { return proto.CompactTextString(m) }
+func (*Song) ProtoMessage()               {}
+func (*Song) Descriptor() ([]byte, []int) { return fileDescriptorProto2, []int{1} }
 
 const Default_Song_Name string = "Type in a Name"
 const Default_Song_Track uint64 = 1
@@ -193,23 +201,24 @@ func (m *Song) GetGood() bool {
 }
 
 type Album struct {
-	Name             *string   `protobuf:"bytes,1,opt,name=Name" json:"Name,omitempty"`
-	Song             []*Song   `protobuf:"bytes,2,rep,name=Song" json:"Song,omitempty"`
-	Genre            *Genre    `protobuf:"varint,3,opt,name=Genre,enum=proto2.Genre,def=1" json:"Genre,omitempty"`
-	Year             *string   `protobuf:"bytes,4,opt,name=Year,def=2015" json:"Year,omitempty"`
-	Producer         []string  `protobuf:"bytes,5,rep,name=Producer" json:"Producer,omitempty"`
-	Mediocre         *bool     `protobuf:"varint,6,opt,name=Mediocre,def=1" json:"Mediocre,omitempty"`
-	Rated            *bool     `protobuf:"varint,7,opt,name=Rated" json:"Rated,omitempty"`
-	Epilogue         *string   `protobuf:"bytes,8,opt,name=Epilogue" json:"Epilogue,omitempty"`
-	Likes            []bool    `protobuf:"varint,9,rep,name=Likes" json:"Likes,omitempty"`
-	Stars            *int64    `protobuf:"varint,10,opt,name=Stars" json:"Stars,omitempty"`
-	Serial           []float64 `protobuf:"fixed64,11,rep,name=Serial" json:"Serial,omitempty"`
+	Name             *string   `protobuf:"bytes,1,opt,name=Name,json=name" json:"Name,omitempty"`
+	Song             []*Song   `protobuf:"bytes,2,rep,name=Song,json=song" json:"Song,omitempty"`
+	Genre            *Genre    `protobuf:"varint,3,opt,name=Genre,json=genre,enum=proto2.Genre,def=1" json:"Genre,omitempty"`
+	Year             *string   `protobuf:"bytes,4,opt,name=Year,json=year,def=2015" json:"Year,omitempty"`
+	Producer         []string  `protobuf:"bytes,5,rep,name=Producer,json=producer" json:"Producer,omitempty"`
+	Mediocre         *bool     `protobuf:"varint,6,opt,name=Mediocre,json=mediocre,def=1" json:"Mediocre,omitempty"`
+	Rated            *bool     `protobuf:"varint,7,opt,name=Rated,json=rated" json:"Rated,omitempty"`
+	Epilogue         *string   `protobuf:"bytes,8,opt,name=Epilogue,json=epilogue" json:"Epilogue,omitempty"`
+	Likes            []bool    `protobuf:"varint,9,rep,name=Likes,json=likes" json:"Likes,omitempty"`
+	Stars            *int64    `protobuf:"varint,10,opt,name=Stars,json=stars" json:"Stars,omitempty"`
+	Serial           []float64 `protobuf:"fixed64,11,rep,name=Serial,json=serial" json:"Serial,omitempty"`
 	XXX_unrecognized []byte    `json:"-"`
 }
 
-func (m *Album) Reset()         { *m = Album{} }
-func (m *Album) String() string { return proto.CompactTextString(m) }
-func (*Album) ProtoMessage()    {}
+func (m *Album) Reset()                    { *m = Album{} }
+func (m *Album) String() string            { return proto.CompactTextString(m) }
+func (*Album) ProtoMessage()               {}
+func (*Album) Descriptor() ([]byte, []int) { return fileDescriptorProto2, []int{2} }
 
 const Default_Album_Genre Genre = Genre_Rock
 const Default_Album_Year string = "2015"
@@ -304,6 +313,10 @@ func init() {
 var _ context.Context
 var _ grpc.ClientConn
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the grpc package it is being compiled against.
+const _ = grpc.SupportPackageIsVersion2
+
 // Client API for Proto2 service
 
 type Proto2Client interface {
@@ -337,16 +350,22 @@ func RegisterProto2Server(s *grpc.Server, srv Proto2Server) {
 	s.RegisterService(&_Proto2_serviceDesc, srv)
 }
 
-func _Proto2_Produce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _Proto2_Produce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(Album)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(Proto2Server).Produce(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(Proto2Server).Produce(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto2.Proto2/Produce",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(Proto2Server).Produce(ctx, req.(*Album))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 var _Proto2_serviceDesc = grpc.ServiceDesc{
@@ -359,4 +378,40 @@ var _Proto2_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams: []grpc.StreamDesc{},
+}
+
+var fileDescriptorProto2 = []byte{
+	// 500 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0x6c, 0x52, 0xd1, 0x6a, 0xdb, 0x30,
+	0x14, 0x9d, 0x63, 0xc9, 0x51, 0x6e, 0xb3, 0x60, 0xc4, 0xd8, 0x44, 0x5f, 0x66, 0xf2, 0xb2, 0x2e,
+	0xb0, 0xb0, 0xb8, 0xec, 0xc5, 0x6f, 0xa5, 0x19, 0xa1, 0xa3, 0x2b, 0x41, 0x29, 0x85, 0x3d, 0x7a,
+	0xb6, 0x08, 0x22, 0x89, 0x64, 0x64, 0xfb, 0xa1, 0xfd, 0xa4, 0x7d, 0xc0, 0xbe, 0x6f, 0x57, 0x8e,
+	0xb3, 0x75, 0xd0, 0x27, 0xfb, 0x1c, 0x1d, 0x9d, 0x7b, 0xee, 0xbd, 0x82, 0x71, 0xe5, 0x6c, 0x63,
+	0xd3, 0x79, 0xf7, 0xe1, 0xd1, 0x11, 0x4d, 0x6f, 0x21, 0xba, 0x72, 0x8d, 0xae, 0x1b, 0xce, 0x81,
+	0xdc, 0xe5, 0x07, 0x25, 0x82, 0x24, 0xb8, 0x18, 0x49, 0x62, 0xf0, 0x9f, 0xcf, 0x81, 0x48, 0xbb,
+	0x57, 0x62, 0x80, 0xdc, 0x24, 0xe5, 0xf3, 0xde, 0xe2, 0xc6, 0xd4, 0x8d, 0x6b, 0x0f, 0xca, 0x34,
+	0x59, 0xb4, 0x6a, 0x75, 0x93, 0x3b, 0x49, 0x1c, 0xea, 0xa6, 0xbf, 0x02, 0x20, 0x1b, 0x6b, 0xb6,
+	0x7c, 0xfa, 0xdc, 0x2c, 0x9b, 0xdc, 0x3f, 0x56, 0x2a, 0xd1, 0x26, 0xc9, 0x13, 0xcf, 0xf6, 0xe6,
+	0xef, 0x80, 0xde, 0xbb, 0xbc, 0xd8, 0x75, 0xee, 0x24, 0x0b, 0x16, 0x92, 0x36, 0x1e, 0xf3, 0xf7,
+	0xc0, 0x96, 0xad, 0xcb, 0x1b, 0x6d, 0x8d, 0x08, 0xf1, 0x2c, 0xc8, 0xc2, 0xcb, 0xf9, 0xa5, 0x64,
+	0x65, 0x4f, 0xf2, 0x19, 0xb0, 0x6b, 0x7b, 0xa8, 0x6c, 0xad, 0x9c, 0x20, 0x49, 0x78, 0x71, 0x96,
+	0x4e, 0x4e, 0xd1, 0x8e, 0xcd, 0x48, 0x56, 0xf4, 0xe7, 0x5c, 0x00, 0x59, 0x59, 0x5b, 0x0a, 0x8a,
+	0x46, 0x2c, 0x23, 0x98, 0x1b, 0xeb, 0x6f, 0x91, 0x99, 0xfe, 0x1e, 0x00, 0xbd, 0xda, 0xff, 0x6c,
+	0x0f, 0x2f, 0xb6, 0x9e, 0x1c, 0x3b, 0xc1, 0x70, 0xde, 0x7f, 0x7c, 0xf2, 0xf7, 0x9c, 0x24, 0xb5,
+	0xef, 0xf1, 0x23, 0xd0, 0x95, 0x32, 0x4e, 0x75, 0x19, 0x27, 0xe9, 0xeb, 0x93, 0xa4, 0x23, 0x33,
+	0x1c, 0x5c, 0xb1, 0x93, 0x74, 0xeb, 0x81, 0x0f, 0xf1, 0x43, 0xe5, 0x3e, 0xac, 0x1f, 0x07, 0x49,
+	0x3f, 0x2f, 0xbe, 0x48, 0xf2, 0x88, 0x0c, 0x3f, 0x07, 0xb6, 0x76, 0xb6, 0x6c, 0x0b, 0x6c, 0x85,
+	0x62, 0xa9, 0x91, 0x64, 0x55, 0x8f, 0x31, 0x02, 0xfb, 0xae, 0x4a, 0x6d, 0x0b, 0xac, 0x11, 0x3d,
+	0x8b, 0xcf, 0x0e, 0x3d, 0xcb, 0xdf, 0x00, 0x95, 0x79, 0xa3, 0x4a, 0x31, 0xf4, 0xc7, 0x92, 0x3a,
+	0x0f, 0xbc, 0xe7, 0xd7, 0x4a, 0xef, 0xed, 0xb6, 0x55, 0x82, 0x75, 0x2d, 0x31, 0xd5, 0x63, 0x7f,
+	0xe3, 0x56, 0xef, 0x54, 0x2d, 0x46, 0x58, 0x0c, 0x6f, 0xec, 0x3d, 0xf0, 0xec, 0x06, 0xb7, 0x58,
+	0x0b, 0x40, 0x79, 0x28, 0x69, 0xed, 0x01, 0x7f, 0x0b, 0xd1, 0x46, 0x39, 0x9d, 0xef, 0xc5, 0x19,
+	0x8a, 0x03, 0x19, 0xd5, 0x1d, 0x9a, 0x7d, 0x02, 0xf8, 0xf7, 0x02, 0xf8, 0x08, 0xe8, 0x83, 0xd5,
+	0x85, 0x8a, 0x5f, 0x71, 0x80, 0xfe, 0x39, 0xc4, 0x01, 0x67, 0x40, 0x96, 0xa8, 0x88, 0x07, 0xb3,
+	0x87, 0x7e, 0x4e, 0x7c, 0x08, 0xe1, 0xda, 0x56, 0xa8, 0x63, 0xd0, 0x4d, 0xe7, 0xa8, 0xfa, 0x96,
+	0x3f, 0x3d, 0xc5, 0x03, 0x1e, 0xc3, 0xf8, 0x4e, 0x9b, 0x46, 0x99, 0xd2, 0x5e, 0x5b, 0xa7, 0xe2,
+	0xd0, 0x1b, 0xdf, 0x98, 0x52, 0xab, 0x98, 0x78, 0xd9, 0xba, 0x35, 0xbb, 0x98, 0x7a, 0x72, 0x99,
+	0x1b, 0xac, 0x16, 0xa5, 0x0b, 0x88, 0xd6, 0xdd, 0xc4, 0xf9, 0x07, 0x18, 0xf6, 0x43, 0xe4, 0x7f,
+	0xb7, 0xd0, 0x6d, 0xf6, 0xfc, 0x7f, 0xf8, 0x27, 0x00, 0x00, 0xff, 0xff, 0x3b, 0x22, 0x00, 0xe2,
+	0x04, 0x03, 0x00, 0x00,
 }


### PR DESCRIPTION
Adds functions in the generated file to get http.Handler instead of
running with the global http.ListenAndServe - Useful for embedding the ui
in other applications. DefaultHandler returns a handler using the
DefaultHtmlStringer, and Handler exposes the stringer as an argument.