### PR TITLE
Now escaping quotes in fields' help texts

### DIFF
--- a/form/form.go
+++ b/form/form.go
@@ -503,7 +503,10 @@ func BuildField(fileDescriptorSet *descriptor.FileDescriptorSet, msg *descriptor
 	tooltip := ""
 	colon := ":"
 	if len(help) > 0 {
-		tooltip = ` <a href="#" data-toggle="tooltip" title="` + strings.Replace(help, "\n", " ", -1) + `"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>`
+		help = strings.Replace(help, "`", "'", -1)
+		help = strings.Replace(help, "'", "\\'", -1)
+		help = strings.Replace(help, "\n", " ", -1)
+		tooltip = ` <a href="#" data-toggle="tooltip" title="` + help + `"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>`
 		colon = ""
 	}
 	fieldname := f.GetName()

--- a/testcmd/serve.proto
+++ b/testcmd/serve.proto
@@ -39,6 +39,7 @@ enum Genre {
 	Jazz = 2;
 	NintendoCore = 3;
 	Indie = 4;
+  // Punk is the definition of `fun`!
 	Punk = 5;
 	Dance = 6;
 }
@@ -48,6 +49,7 @@ message Artist {
 	Instrument Role = 2;
 }
 
+// Song is the piece of audio you're listening.
 message Song {
 	string Name = 1;
 	uint64 Track = 2;
@@ -59,6 +61,7 @@ message Album {
 	string Name = 1;
 	repeated Song Song = 2;
 	Genre Genre = 3;
+  // Year... uh... `test` 'test'
 	string Year = 4;
 	repeated string Producer = 5;
 }


### PR DESCRIPTION
Now escaping \` quote which breaks generated Go files and ' quote, which breaks JS.
Closes issue #23.