### PR TITLE
Fix proto message type parsing.

### DIFF
--- a/form/form.go
+++ b/form/form.go
@@ -450,7 +450,8 @@ func isNumber(f *descriptor.FieldDescriptorProto) bool {
 
 func getMessage(f *descriptor.FieldDescriptorProto, fileDescriptorSet *descriptor.FileDescriptorSet) *descriptor.DescriptorProto {
 	typeNames := strings.Split(f.GetTypeName(), ".")
-	packageName, messageName := typeNames[1], typeNames[2]
+	messageName := typeNames[len(typeNames)-1]
+	packageName := strings.Join(typeNames[1:len(typeNames)-1], ".")
 	return fileDescriptorSet.GetMessage(packageName, messageName)
 }
 

--- a/form/form.proto
+++ b/form/form.proto
@@ -25,7 +25,7 @@
 
 syntax = "proto3";
 
-package form;
+package weird.form;
 
 message Weird {
 	string Name = 1;

--- a/form/form_test.go
+++ b/form/form_test.go
@@ -61,7 +61,7 @@ func TestCreateCustom(t *testing.T) {
 	g.BuildTypeNameMap()
 	g.Reset()
 	g.SetFile(desc.File[0])
-	formStr = CreateCustom("WeirdMethod", "form", "Weird", g, CustomBuildField)
+	formStr = CreateCustom("WeirdMethod", "weird.form", "Weird", g, CustomBuildField)
 	testserver := httptest.NewServer(http.HandlerFunc(handle))
 	defer testserver.Close()
 	resp, err := http.Get(testserver.URL + "/WeirdMethod?json={%22Name%22:%22%22,%22WeirdName%22:%22another%20string%22,%22Number%22:null}")


### PR DESCRIPTION
The current implementation was assuming single word package names. This
allows multiple word package names (like google.api).