### PR TITLE
fixed enums nested in msgs

### DIFF
--- a/form/form.go
+++ b/form/form.go
@@ -423,6 +423,9 @@ func isEnum(f *descriptor.FieldDescriptorProto) bool {
 
 func getEnum(fileDescriptorSet *descriptor.FileDescriptorSet, f *descriptor.FieldDescriptorProto) *descriptor.EnumDescriptorProto {
 	typeNames := strings.Split(f.GetTypeName(), ".")
+	if len(typeNames) > 3 {
+  	return fileDescriptorSet.GetMessage(typeNames[1], typeNames[2]).GetEnumType()[0]
+  }
 	return fileDescriptorSet.GetEnum(typeNames[1], typeNames[2])
 }
 


### PR DESCRIPTION
a simple fix - checks to see if the name is long enough (i.e. the enum is in a message), then retrieves the message, then the enum.